### PR TITLE
Fixed memory leak

### DIFF
--- a/DHCP/README.md
+++ b/DHCP/README.md
@@ -5,7 +5,7 @@ This library class enables Dynamic Host Configuration Protocol (DHCP) functional
 **To include this library in your project, add the following at the top of your device code:**
 
 ```squirrel
-#require "W5500.device.lib.nut:2.2.0"
+#require "W5500.device.lib.nut:2.2.1"
 #require "W5500.DHCP.device.lib.nut:2.0.1"
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Wiznet W5500 2.2.0 #
+# Wiznet W5500 2.2.1 #
 
 The W5500 chip is a hardwired TCP/IP embedded Ethernet controller. We have two libraries for use with the [Wiznet W5500 chip](http://wizwiki.net/wiki/lib/exe/fetch.php?media=products:w5500:w5500_ds_v106e_141230.pdf).
 
@@ -8,7 +8,7 @@ In addition we have a W5500.DHCP library that enables Dynamic Host Configuration
 
 The W5500 is used by the [impAccelerator&trade; Fieldbus Gateway](https://developer.electricimp.com/hardware/resources/reference-designs/fieldbusgateway).
 
-**To include the base library in your project, add** `#require "W5500.device.lib.nut:2.2.0"` **at the top of your device code**
+**To include the base library in your project, add** `#require "W5500.device.lib.nut:2.2.1"` **at the top of your device code**
 
 ## W5500 Class Usage ##
 

--- a/W5500.device.lib.nut
+++ b/W5500.device.lib.nut
@@ -2151,6 +2151,7 @@ class W5500.Connection {
         _driver.closeConnection(_socket, _getHandler("close"));
         _handlers = {};
         if (_interrupt_timer) imp.cancelwakeup(_interrupt_timer);
+       _interrupt_timer = null;
     }
 
 
@@ -2266,6 +2267,7 @@ class W5500.Connection {
     // Parameters: socket the interrupt occurred on
     // **************************************************************************
     function handleInterrupt(skip_timer = false) {
+        _interrupt_timer = null;
 
         local status = _driver.getSocketInterruptTypeStatus(_socket);
 

--- a/W5500.device.lib.nut
+++ b/W5500.device.lib.nut
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright 2016-2019 Electric Imp
+// Copyright 2016-2021 Electric Imp
 //
 // SPDX-License-Identifier: MIT
 //
@@ -270,7 +270,7 @@ const W5500_INTERRUPT_POLL_TIME_ACTIVE = 0.01;
 
 class W5500 {
 
-    static VERSION   = "2.2.0";
+    static VERSION   = "2.2.1";
 
     _driver          = null;
     // Set to true once the driver is loaded and connection to chip made
@@ -2267,6 +2267,7 @@ class W5500.Connection {
     // Parameters: socket the interrupt occurred on
     // **************************************************************************
     function handleInterrupt(skip_timer = false) {
+        if (_interrupt_timer) imp.cancelwakeup(_interrupt_timer);
         _interrupt_timer = null;
 
         local status = _driver.getSocketInterruptTypeStatus(_socket);
@@ -2395,7 +2396,6 @@ class W5500.Connection {
         }
 
         // Scan the interrupt again very soon
-        if (_interrupt_timer) imp.cancelwakeup(_interrupt_timer);
         if (_socket in _driver._connections) {
             local timer_time = ("receive" in _handlers) ? W5500_INTERRUPT_POLL_TIME_ACTIVE : W5500_INTERRUPT_POLL_TIME_IDLE;
             _interrupt_timer = imp.wakeup(timer_time, handleInterrupt.bindenv(this))

--- a/examples/BasicUsageExample.device.nut
+++ b/examples/BasicUsageExample.device.nut
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright 2016-2019 Electric Imp
+// Copyright 2016-2021 Electric Imp
 //
 // SPDX-License-Identifier: MIT
 //
@@ -22,7 +22,7 @@
 // ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 // OTHER DEALINGS IN THE SOFTWARE.
 
-#require "W5500.device.lib.nut:2.2.0"
+#require "W5500.device.lib.nut:2.2.1"
 
 //================================================
 // Define Settings

--- a/examples/DHCP_Example.device.nut
+++ b/examples/DHCP_Example.device.nut
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright 2016-2019 Electric Imp
+// Copyright 2016-2021 Electric Imp
 //
 // SPDX-License-Identifier: MIT
 //
@@ -26,7 +26,7 @@
 // Hardware: imp005 Fieldbus Gateway
 
 // Include Libraries
-#require "W5500.device.lib.nut:2.2.0"
+#require "W5500.device.lib.nut:2.2.1"
 #require "W5500.DHCP.device.lib.nut:2.0.1"
 
 // Configure Echo Server Settings


### PR DESCRIPTION
After closing a connection, the `W5500.Connection` instance doesn't release memory, because `_interrupt_timer` keeps a strong reference to the instance.
Fixed by setting `_interrupt_timer = null` every time the timer fires.